### PR TITLE
dplyr filter 

### DIFF
--- a/app.R
+++ b/app.R
@@ -631,7 +631,7 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
           mutate(PML = calc(PML_GET))
         preterm_df <-
           preterm_df %>% mutate(`postmenstruele leeftijd` = PML,
-                                biliwaarde = biliprem) %>% select(`postmenstruele leeftijd`, biliwaarde) %>% filter(biliwaarde > 0)
+                                biliwaarde = biliprem) %>% select(`postmenstruele leeftijd`, biliwaarde) %>% dplyr::filter(biliwaarde > 0)
         list(df = preterm_df, df_PT = df_PT)
       }
     } else if (input$prematuur == "nee") {
@@ -696,7 +696,7 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
       }
     }
     
-    df <- df %>% filter(biliwaarde > 0)
+    df <- df %>% dplyr::filter(biliwaarde > 0)
     df <- df %>% mutate_if(is.numeric, ~ round(., 2))
     
     df$risicofactoren <- input$bili_risk
@@ -750,36 +750,36 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
         highlight = NA
         ggplot_text <- "No Hyperbilirubinemia Neurotoxicity Risk Factors"
         df <- read_tsv("./data/all_norisk.tsv")
-        df <- df %>% filter(!is.na(bilirubin))
+        df <- df %>% dplyr::filter(!is.na(bilirubin))
         df <- df %>% arrange(annotation,time)
         df <- df %>% 
           group_by(annotation) %>%
-          filter(!duplicated(bilirubin))
-        max_vals <- df  %>% group_by(annotation)  %>% summarise(bilirubin = max(bilirubin, na.rm = TRUE)) %>% mutate(time = 336) %>% filter(!is.na(annotation))
+          dplyr::filter(!duplicated(bilirubin))
+        max_vals <- df  %>% group_by(annotation)  %>% summarise(bilirubin = max(bilirubin, na.rm = TRUE)) %>% mutate(time = 336) %>% dplyr::filter(!is.na(annotation))
         df <- rbind(max_vals, df)
        
         if (PML_geboorte < 36 && PML_geboorte >= 35){
-          #df <- df %>% filter(annotation == "35w_norisk")
+          #df <- df %>% dplyr::filter(annotation == "35w_norisk")
           df$annotation <- sub("35w_norisk", "35 weeks", df$annotation)
           highlight <- "35 weeks"
         } else if (PML_geboorte < 37 && PML_geboorte >= 36){
-          #df <- df %>% filter(annotation == "36w_norisk")
+          #df <- df %>% dplyr::filter(annotation == "36w_norisk")
           df$annotation <- sub("36w_norisk", "36 weeks", df$annotation)
           highlight <- "36 weeks"
         } else if (PML_geboorte < 38 && PML_geboorte >= 37){
-          #df <- df %>% filter(annotation == "37w_norisk")
+          #df <- df %>% dplyr::filter(annotation == "37w_norisk")
           df$annotation <- sub("37w_norisk", "37 weeks", df$annotation)
           highlight <- "37 weeks"
         } else if (PML_geboorte < 39 && PML_geboorte >= 38){
-          #df <- df %>% filter(annotation == "38w_norisk")
+          #df <- df %>% dplyr::filter(annotation == "38w_norisk")
           df$annotation <- sub("38w_norisk", "38 weeks", df$annotation)
           highlight <- "38 weeks"
         } else if (PML_geboorte < 40 && PML_geboorte >= 39){
-          #df <- df %>% filter(annotation == "39w_norisk")
+          #df <- df %>% dplyr::filter(annotation == "39w_norisk")
           df$annotation <- sub("39w_norisk", "39 weeks", df$annotation)
           highlight <- "39 weeks"
         } else if (PML_geboorte >= 40){
-          #df <- df %>% filter(annotation == "40w_norisk")
+          #df <- df %>% dplyr::filter(annotation == "40w_norisk")
           df$annotation <- sub("40w_norisk", ">= 40 weeks", df$annotation)
           highlight <- ">= 40 weeks"
         }
@@ -787,28 +787,28 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
         highlight = NA
         ggplot_text <- "One or More Hyperbilirubinemia Neurotoxicity Risk Factors"
         df <- read_tsv("./data/all_risk.tsv")
-        df <- df %>% filter(!is.na(bilirubin))
+        df <- df %>% dplyr::filter(!is.na(bilirubin))
         df <- df %>% arrange(annotation,time)
         df <- df %>% 
           group_by(annotation, bilirubin) %>%
-          filter(!duplicated(bilirubin))
-        max_vals <- df  %>% group_by(annotation)  %>% summarise(bilirubin = max(bilirubin, na.rm = TRUE)) %>% mutate(time = 336) %>% filter(!is.na(annotation))
+          dplyr::filter(!duplicated(bilirubin))
+        max_vals <- df  %>% group_by(annotation)  %>% summarise(bilirubin = max(bilirubin, na.rm = TRUE)) %>% mutate(time = 336) %>% dplyr::filter(!is.na(annotation))
         df <- rbind(max_vals, df)
         
         if (PML_geboorte < 36 && PML_geboorte >= 35){
-          #df <- df %>% filter(annotation == "35w_risk")
+          #df <- df %>% dplyr::filter(annotation == "35w_risk")
           df$annotation <- sub("35w_risk", "35 weeks", df$annotation)
           highlight <- "35 weeks"
         } else if (PML_geboorte < 37 && PML_geboorte >= 36){
-          #df <- df %>% filter(annotation == "36w_risk")
+          #df <- df %>% dplyr::filter(annotation == "36w_risk")
           df$annotation <- sub("36w_risk", "36 weeks", df$annotation)
           highlight <- "36 weeks"
         } else if (PML_geboorte < 38 && PML_geboorte >= 37){
-          #df <- df %>% filter(annotation == "37w_risk")
+          #df <- df %>% dplyr::filter(annotation == "37w_risk")
           df$annotation <- sub("37w_risk", "37 weeks", df$annotation)
           highlight <- "37 weeks"
         } else if (PML_geboorte >= 38){
-          #df <- df %>% filter(annotation == "38w_risk")
+          #df <- df %>% dplyr::filter(annotation == "38w_risk")
           df$annotation <- sub("38w_risk", ">= 38 weeks", df$annotation)
           highlight <- ">= 38 weeks"          
         }
@@ -845,9 +845,9 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
       )
       df_all <- bind_rows(df, df_TcB)
       # extract the most recent entered value to annotate the corresponding thresholds for LR, MR and HR on the plot
-      x_seq = df2 %>% filter(biliwaarde > 0) %>% pull(`tijd in dagen`)
+      x_seq = df2 %>% dplyr::filter(biliwaarde > 0) %>% pull(`tijd in dagen`)
       
-      intersections <- df_all %>% filter(annotation != "sample") %>% filter(annotation == highlight | annotation == "threshold for serum confirmation of TcB if no risk factors") %>%
+      intersections <- df_all %>% dplyr::filter(annotation != "sample") %>% dplyr::filter(annotation == highlight | annotation == "threshold for serum confirmation of TcB if no risk factors") %>%
         group_by(annotation) %>%
         dplyr::reframe(interpolated = approx(x = `tijd in dagen`, y = biliwaarde, xout = x_seq)$y) %>%
         mutate(x_seq = rep(x_seq, 2)) %>%
@@ -895,22 +895,22 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
         PT_legend <- NULL
       }
       
-      #if (df %>% filter(annotation == "sample") %>% pull(`tijd in dagen`) %>% max() > 7) {
+      #if (df %>% dplyr::filter(annotation == "sample") %>% pull(`tijd in dagen`) %>% max() > 7) {
       #  highest_xlim <- 14
       #} else{ 
       #  highest_xlim <- 7
       #}
 
-      if (df %>% filter(annotation == "sample", biliwaarde > 0) %>% pull(`biliwaarde`) %>% min() > 6) {
+      if (df %>% dplyr::filter(annotation == "sample", biliwaarde > 0) %>% pull(`biliwaarde`) %>% min() > 6) {
         lowest_ylim <- 6
       } else{ 
-        lowest_ylim <- df %>% filter(annotation == "sample", biliwaarde > 0) %>% pull(`biliwaarde`) %>% min() 
+        lowest_ylim <- df %>% dplyr::filter(annotation == "sample", biliwaarde > 0) %>% pull(`biliwaarde`) %>% min() 
       }
 
-      if (df %>% filter(annotation == "sample", biliwaarde > 0) %>% pull(`biliwaarde`) %>% max() < 22.5) {
+      if (df %>% dplyr::filter(annotation == "sample", biliwaarde > 0) %>% pull(`biliwaarde`) %>% max() < 22.5) {
         highest_ylim <- 22.5
       } else{ 
-        highest_ylim <- df %>% filter(annotation == "sample", biliwaarde > 0) %>% pull(`biliwaarde`) %>% max() 
+        highest_ylim <- df %>% dplyr::filter(annotation == "sample", biliwaarde > 0) %>% pull(`biliwaarde`) %>% max() 
       }      
       
       g <-
@@ -933,15 +933,15 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
           nudge_x = 1,
           force = 1
         )  +
-        geom_line(data = df %>% filter(annotation != "sample") %>% filter(annotation == highlight), size = 1)  + 
-        geom_line(data = df %>% filter(annotation != "sample") %>% filter(annotation != highlight), aes(group = annotation, col = annotation), size = 0.5, color = "gray80")  + 
+        geom_line(data = df %>% dplyr::filter(annotation != "sample") %>% dplyr::filter(annotation == highlight), size = 1)  + 
+        geom_line(data = df %>% dplyr::filter(annotation != "sample") %>% dplyr::filter(annotation != highlight), aes(group = annotation, col = annotation), size = 0.5, color = "gray80")  + 
         theme_bw() + xlab("age in days") + ylab("bilirubin, mg/dL") +
         geom_line(data = df_TcB, linetype = "dashed", size = 1) +
         geom_point(
-          data = df %>% filter(annotation == "sample", biliwaarde > 0),
+          data = df %>% dplyr::filter(annotation == "sample", biliwaarde > 0),
           aes(y = biliwaarde, x = `tijd in dagen`, col = annotation),
           size = 3, color = "#5E81AC"
-        ) + geom_line(data = df %>% filter(annotation == "sample", biliwaarde > 0), aes(group = annotation), color = "#5E81AC") + labs(color = "legend", subtitle = paste0(ggplot_text, "\n", "°", df2 %>% pull(geboorte) %>% first()) ) + theme(
+        ) + geom_line(data = df %>% dplyr::filter(annotation == "sample", biliwaarde > 0), aes(group = annotation), color = "#5E81AC") + labs(color = "legend", subtitle = paste0(ggplot_text, "\n", "°", df2 %>% pull(geboorte) %>% first()) ) + theme(
           text = element_text(size = 20),
           legend.position = "bottom",
           legend.direction="vertical",
@@ -953,7 +953,7 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
                            limits = c(lowest_ylim, highest_ylim)) +
         scale_color_manual(values = c( "#4C566A", "#88C0D0")) +
         theme(plot.subtitle=element_text(size=18)) +
-        geom_point(data = intersections %>% filter(x_seq > 0) , aes(x = x_seq, y = interpolated)) + PT_ggplot + PT_legend
+        geom_point(data = intersections %>% dplyr::filter(x_seq > 0) , aes(x = x_seq, y = interpolated)) + PT_ggplot + PT_legend
       
       g + guides(color = guide_legend(nrow = 5))
     } else{
@@ -1028,7 +1028,7 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
       alpha = 0.1
       
       ggplot(
-        preterm_df %>% filter(biliwaarde > 0),
+        preterm_df %>% dplyr::filter(biliwaarde > 0),
         aes(x = `postmenstruele leeftijd`, y = biliwaarde)
       ) +
         geom_point(size = 3,

--- a/app_EN.R
+++ b/app_EN.R
@@ -620,7 +620,7 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
           mutate(`postmenstrual age` = GA,
                  bili_value = biliprem) %>%
           dplyr::select(`postmenstrual age`, bili_value) %>%
-          filter(bili_value > 0)
+          dplyr::filter(bili_value > 0)
         list(df = preterm_df, df_PT = df_PT)
       }
     }
@@ -692,7 +692,7 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
       }
     }
     
-    df <- df %>% filter(bili_value > 0)
+    df <- df %>% dplyr::filter(bili_value > 0)
     df <- df %>% mutate_if(is.numeric, ~ round(., 2))
     
     df$risk_factors <- input$bili_risk
@@ -738,12 +738,12 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
         highlight <- NA
         ggplot_text <- "No Hyperbilirubinemia Neurotoxicity Risk Factors"
         df <- read_tsv("./data/all_norisk.tsv")
-        df <- df %>% filter(!is.na(bilirubin))
+        df <- df %>% dplyr::filter(!is.na(bilirubin))
         df <- df %>% arrange(annotation, time)
         df <- df %>% 
           group_by(annotation) %>%
-          filter(!duplicated(bilirubin))
-        max_vals <- df %>% group_by(annotation) %>% summarise(bilirubin = max(bilirubin, na.rm = TRUE)) %>% mutate(time = 336) %>% filter(!is.na(annotation))
+          dplyr::filter(!duplicated(bilirubin))
+        max_vals <- df %>% group_by(annotation) %>% summarise(bilirubin = max(bilirubin, na.rm = TRUE)) %>% mutate(time = 336) %>% dplyr::filter(!is.na(annotation))
         df <- rbind(max_vals, df)
         
         if (GA_birth < 36 && GA_birth >= 35) {
@@ -769,12 +769,12 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
         highlight <- NA
         ggplot_text <- "One or More Hyperbilirubinemia Neurotoxicity Risk Factors"
         df <- read_tsv("./data/all_risk.tsv")
-        df <- df %>% filter(!is.na(bilirubin))
+        df <- df %>% dplyr::filter(!is.na(bilirubin))
         df <- df %>% arrange(annotation, time)
         df <- df %>% 
           group_by(annotation, bilirubin) %>%
-          filter(!duplicated(bilirubin))
-        max_vals <- df %>% group_by(annotation) %>% summarise(bilirubin = max(bilirubin, na.rm = TRUE)) %>% mutate(time = 336) %>% filter(!is.na(annotation))
+          dplyr::filter(!duplicated(bilirubin))
+        max_vals <- df %>% group_by(annotation) %>% summarise(bilirubin = max(bilirubin, na.rm = TRUE)) %>% mutate(time = 336) %>% dplyr::filter(!is.na(annotation))
         df <- rbind(max_vals, df)
         
         if (GA_birth < 36 && GA_birth >= 35) {
@@ -802,9 +802,9 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
       bili_value = c(8, 10, 12, 14, 17)
     )
     df_all <- bind_rows(df, df_TcB)
-    x_seq = df2 %>% filter(bili_value > 0) %>% pull(`time in days`)
+    x_seq = df2 %>% dplyr::filter(bili_value > 0) %>% pull(`time in days`)
     
-    intersections <- df_all %>% filter(annotation != "sample") %>% filter(annotation == highlight | annotation == "threshold for serum confirmation of TcB if no risk factors") %>%
+    intersections <- df_all %>% dplyr::filter(annotation != "sample") %>% dplyr::filter(annotation == highlight | annotation == "threshold for serum confirmation of TcB if no risk factors") %>%
       group_by(annotation) %>%
       dplyr::reframe(interpolated = approx(x = `time in days`, y = bili_value, xout = x_seq)$y) %>%
       mutate(x_seq = rep(x_seq, 2)) %>%
@@ -860,15 +860,15 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
         nudge_x = 1,
         force = 1
       )  +
-      geom_line(data = df %>% filter(annotation != "sample") %>% filter(annotation == highlight), size = 1)  + 
-      geom_line(data = df %>% filter(annotation != "sample") %>% filter(annotation != highlight), aes(group = annotation, col = annotation), size = 0.5, color = "gray80")  + 
+      geom_line(data = df %>% dplyr::filter(annotation != "sample") %>% dplyr::filter(annotation == highlight), size = 1)  + 
+      geom_line(data = df %>% dplyr::filter(annotation != "sample") %>% dplyr::filter(annotation != highlight), aes(group = annotation, col = annotation), size = 0.5, color = "gray80")  + 
       theme_bw() + xlab("age in days") + ylab("bilirubin, mg/dL") +
       geom_line(data = df_TcB, linetype = "dashed", size = 1) +
       geom_point(
-        data = df %>% filter(annotation == "sample", bili_value > 0),
+        data = df %>% dplyr::filter(annotation == "sample", bili_value > 0),
         aes(y = bili_value, x = `time in days`, col = annotation),
         size = 3, color = "#5E81AC"
-      ) + geom_line(data = df %>% filter(annotation == "sample", bili_value > 0), aes(group = annotation), color = "#5E81AC") + labs(color = "legend", subtitle = paste0(ggplot_text, "\n", "°", df2 %>% pull(birth) %>% first()) ) + theme(
+      ) + geom_line(data = df %>% dplyr::filter(annotation == "sample", bili_value > 0), aes(group = annotation), color = "#5E81AC") + labs(color = "legend", subtitle = paste0(ggplot_text, "\n", "°", df2 %>% pull(birth) %>% first()) ) + theme(
         text = element_text(size = 20),
         legend.position = "bottom",
         legend.direction="vertical",
@@ -878,7 +878,7 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
                          limits = c(5, 22.5)) +
       scale_color_manual(values = c( "#4C566A", "#88C0D0")) +
       theme(plot.subtitle=element_text(size=18)) +
-      geom_point(data = intersections %>% filter(x_seq > 0) , aes(x = x_seq, y = interpolated)) + PT_ggplot + PT_legend
+      geom_point(data = intersections %>% dplyr::filter(x_seq > 0) , aes(x = x_seq, y = interpolated)) + PT_ggplot + PT_legend
     
     g + guides(color = guide_legend(nrow = 5))
   } else{
@@ -901,7 +901,7 @@ server <- function(input, output, session) {options(shiny.usecairo=TRUE)
     alpha = 0.1
     
     ggplot(
-      preterm_df %>% filter(bili_value > 0),
+      preterm_df %>% dplyr::filter(bili_value > 0),
       aes(x = `postmenstrual age`, y = bili_value)
     ) +
       geom_point(size = 3,

--- a/create_df.R
+++ b/create_df.R
@@ -37,17 +37,17 @@ for(nbr in 1:length(files)){
 
 
 all_data$bilirubin <- as.double(all_data$bilirubin)
-max_vals <- all_data %>% group_by(annotation)  %>% summarise(bilirubin = max(bilirubin, na.rm = TRUE)) %>% mutate(time = 360) %>% filter(!is.na(annotation))
+max_vals <- all_data %>% group_by(annotation)  %>% summarise(bilirubin = max(bilirubin, na.rm = TRUE)) %>% mutate(time = 360) %>% dplyr::filter(!is.na(annotation))
 all_data <- rbind(max_vals, all_data)
 #write_tsv(all_data, "./data/all_norisk.tsv")
 
 ggplot(all_data, aes(x = time/24, y = bilirubin, col = annotation)) + geom_line() + ylim(0,20) + xlim(0,16)
-all_data <- all_data %>% filter(annotation == "35w_norisk")
+all_data <- all_data %>% dplyr::filter(annotation == "35w_norisk")
 g <-
   ggplot(all_data, aes(y = bilirubin, x = time/24, col = annotation, linetype = annotation)) +
-  geom_line(data = all_data %>% filter(annotation != "sample"))  + theme_bw() + xlim(0, 7) + ylim(3, 25) + xlab("age in days") + ylab("bilirubin, mg/dL") +
+  geom_line(data = all_data %>% dplyr::filter(annotation != "sample"))  + theme_bw() + xlim(0, 7) + ylim(3, 25) + xlab("age in days") + ylab("bilirubin, mg/dL") +
   geom_point(
-    data = all_data %>% filter(annotation == "sample", bilirubin > 0),
+    data = all_data %>% dplyr::filter(annotation == "sample", bilirubin > 0),
     aes(y = bilirubin, x = time/24, col = annotation),
     size = 3
   ) + theme(


### PR DESCRIPTION
Ik kreeg conflicts op de aanroepen van "filter". In deze pull request worden alle aanroepen van `filter` vervangen door `dplyr::filter`

ignoring --preserve-environment, it's mutually exclusive with --login
── Attaching core tidyverse packages ──────────────────────── tidyverse 2.0.0 ──
✔ dplyr     1.1.4     ✔ readr     2.1.4
✔ forcats   1.0.0     ✔ stringr   1.5.0
✔ ggplot2   3.4.4     ✔ tibble    3.2.1
✔ lubridate 1.9.3     ✔ tidyr     1.3.0
✔ purrr     1.0.2     
── Conflicts ────────────────────────────────────────── tidyverse_conflicts() ──
✖ dplyr::filter() masks stats::filter()
✖ dplyr::lag()    masks stats::lag()
ℹ Use the conflicted package (http://conflicted.r-lib.org/) to force all conflicts to become errors

Attaching package: ‘DT’

The following objects are masked from ‘package:shiny’:

    dataTableOutput, renderDataTable


Attaching package: ‘shinyscreenshot’

The following object is masked from ‘package:shiny’:

    runExample


Listening on http://127.0.0.1:35719/